### PR TITLE
changing form to formData

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -48,7 +48,7 @@ function expressroutes(router, options) {
                         value = req.header(parameter.name);
                         break;
                     case 'body':
-                    case 'form':
+                    case 'formData':
                         value = req.body;
                 }
 


### PR DESCRIPTION
According to the Swagger 2.0 spec, the "in" parameter should be 'formData' instead of 'form': https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields-7
